### PR TITLE
210312 소수의 연속합, 주사위 굴리기

### DIFF
--- a/jeehyun/개별문제/Baekjoon/1644_소수의 연속합.cpp
+++ b/jeehyun/개별문제/Baekjoon/1644_소수의 연속합.cpp
@@ -1,0 +1,64 @@
+/* 브루트포스
+ * 1644 소수의 연속합
+ */
+
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#define MAX 4000001
+using namespace std;
+
+bool prime[MAX];
+
+
+int main()
+{
+	ios::sync_with_stdio(false);
+	cin.tie(NULL);
+	cout.tie(NULL);
+
+	int n;
+	cin >> n;
+
+	fill_n(prime, n + 1, 1);
+	prime[0] = prime[1] = false;
+
+	// 에라토스테네스의 체
+	for (int i = 2; i <= n; i++) {
+		if (prime[i]) {
+			for (int j = i * 2; j <= n; j += i)
+				prime[j] = false;
+		}
+	}
+
+	vector<int> primes;
+	for (int i = 2; i <= n; i++) {
+		if (prime[i]) {
+			primes.push_back(i);
+		}
+	}
+
+	int answer = 0;
+	int size = primes.size();
+	int left = 0, right = 0;
+	int sum = 0;
+
+	// 투 포인터 알고리즘 O(1)
+	while (right <= size && left <= right) {
+		if (sum >= n) {
+			if (sum == n)
+				answer++;
+
+			sum -= primes[left++];
+		}
+		else {
+			if (right == size)
+				break;
+
+			sum += primes[right++];
+		}
+	}
+	cout << answer;
+
+	return 0;
+}

--- a/jeehyun/공통문제/백준/14499_주사위 굴리기.cpp
+++ b/jeehyun/공통문제/백준/14499_주사위 굴리기.cpp
@@ -1,0 +1,75 @@
+#include <iostream>
+#include <vector>
+using namespace std;
+
+int n, m;
+int map[21][21];
+vector<int> dice(6);
+
+int dx[] = { 0, 0, -1, 1}; // 동서북남
+int dy[] = { 1, -1, 0, 0};
+
+void rollDice(int dir)
+{
+    switch (dir) {
+    case 1: // 동
+        dice = { dice[3], dice[1], dice[0], dice[5], dice[4], dice[2] };
+        break;
+    case 2: // 서
+        dice = { dice[2], dice[1], dice[5], dice[0], dice[4], dice[3] };
+        break;
+    case 3: // 북
+        dice = { dice[4], dice[0], dice[2], dice[3], dice[5], dice[1] };
+        break;
+    case 4: // 남
+        dice = { dice[1], dice[5], dice[2], dice[3], dice[0], dice[4] };
+        break;
+    }
+}
+
+int main()
+{
+    ios::sync_with_stdio(false);
+    cin.tie(NULL);
+    cout.tie(NULL);
+
+    int x, y, k;
+    cin >> n >> m >> x >> y >> k;
+
+    for (int i = 0; i < n; i++) {
+        for (int j = 0; j < m; j++)
+            cin >> map[i][j];
+    }
+
+    int dir;
+
+    for (int i = 0; i < k; i++) {
+        cin >> dir;
+
+        int nx = x + dx[dir - 1];
+        int ny = y + dy[dir - 1];
+
+        // 지도의 바깥일 경우 명령 무시
+        if (nx < 0 || ny < 0 || nx >= n || ny >= m)
+            continue;
+
+        rollDice(dir);
+
+        // 이동한 칸에 쓰여있는 수가 0이 아닌 경우에는 칸에 쓰여 있는 수를 주사위의 바닥면으로 복사
+        if (map[nx][ny]) {
+            dice[5] = map[nx][ny];
+            map[nx][ny] = 0;
+        }
+        else { // 0일 경우 주사위의 바닥면에 쓰여 있는 수를 칸에 복사
+            map[nx][ny] = dice[5];
+        }
+
+        // 주사위 상단에 쓰여있는 값 출력
+        cout << dice[0] << '\n';
+
+        x = nx;
+        y = ny;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
##### &#128213; **풀이한 문제**

- 백준 1644 소수의 연속합
- 백준 14499 주사위 굴리기



------



⭐ **문제에서 주로 사용한 알고리즘**

- 에라토스테네스의 체
- 투 포인터 알고리즘



------



&#128220; **코드 설명**

- 1644 소수의 연속합

  - 우선 에라토스테네스의 체를 사용하여 n 이하의 소수를 찾는다

  - n 이하의 소수로 구성된 배열을 만든다

  - 투 포인터 알고리즘으로 연속합을 구한다

    

- 14499 주사위 굴리기

  - 이 문제는 주사위의 상태가 중요하다
  - 주사위를 굴릴 때마다 dice 배열의 순서를 바꿔주면 된다
    동 (1) &#10141; { 3, 1, 0, 5, 4, 2 }
    서 (2) &#10141; { 2, 1, 5, 0, 4, 3 }
    북 (3) &#10141; { 4, 0, 2, 3, 5, 1 }
    남 (4) &#10141; { 1, 5, 2, 3, 0, 4 }

